### PR TITLE
fix: use symbol keys for CREATED property lookup

### DIFF
--- a/test/vulpea-journal-test.el
+++ b/test/vulpea-journal-test.el
@@ -327,5 +327,42 @@ after a full scan rebuild."
                          (buffer-string))
                        original-content)))))
 
+;;; Created Today Query Tests
+
+(ert-deftest vulpea-journal-ui-created-today-extracts-time ()
+  "Test that created-today query extracts CREATED time from properties.
+The CREATED property is stored in the :PROPERTIES: drawer, and
+`vulpea-note-properties' returns an alist with symbol keys.
+The query function must read the time to sort notes by creation time."
+  (vulpea-test--with-temp-db
+    (let* ((vulpea-journal-default-template
+            '(:file-name "journal/%Y-%m-%d.org"
+              :title "%Y-%m-%d %A"
+              :tags ("journal")))
+           (date (encode-time 0 0 12 25 11 2024))
+           ;; Create journal entry for the date
+           (_journal (vulpea-journal-note date))
+           ;; Create two non-journal notes with CREATED property
+           (note-early (vulpea-create "Morning note" nil
+                         :tags '("project")
+                         :properties '(("CREATED" . "[2024-11-25 Mon 09:00]"))))
+           (note-late (vulpea-create "Afternoon note" nil
+                        :tags '("project")
+                        :properties '(("CREATED" . "[2024-11-25 Mon 14:30]")))))
+      (require 'vulpea-journal-ui)
+      (let* ((vulpea-journal-ui-created-today-exclude-journal t)
+             (results (vulpea-journal-ui--query-created-today date))
+             (titles (mapcar #'vulpea-note-title results)))
+        ;; Should find both non-journal notes
+        (should (= 2 (length results)))
+        ;; Should be sorted by time: 09:00 before 14:30
+        (should (equal titles '("Morning note" "Afternoon note")))
+        ;; Verify CREATED property is accessible from returned notes
+        (let* ((first-note (car results))
+               (props (vulpea-note-properties first-note))
+               (created (alist-get 'CREATED props)))
+          (should created)
+          (should (string-match-p "09:00" created)))))))
+
 (provide 'vulpea-journal-test)
 ;;; vulpea-journal-test.el ends here

--- a/vulpea-journal-ui.el
+++ b/vulpea-journal-ui.el
@@ -203,9 +203,9 @@ Notes without time appear first, then sorted by time ascending."
          (--filter (or (not vulpea-journal-ui-created-today-exclude-journal)
                        (not (vulpea-journal-note-p it))))
          (--sort (let ((time-a (vulpea-journal-ui--extract-time
-                                (cdr (assoc "CREATED" (vulpea-note-properties it)))))
+                                (alist-get 'CREATED (vulpea-note-properties it))))
                        (time-b (vulpea-journal-ui--extract-time
-                                (cdr (assoc "CREATED" (vulpea-note-properties other))))))
+                                (alist-get 'CREATED (vulpea-note-properties other)))))
                    (cond
                     ;; Both have no time - keep original order
                     ((and (null time-a) (null time-b)) nil)
@@ -406,7 +406,7 @@ ON-SELECT is callback to handle date selection."
            (lambda (n)
              (let* ((title (vulpea-note-title n))
                     (tags (vulpea-note-tags n))
-                    (created (cdr (assoc "CREATED" (vulpea-note-properties n))))
+                    (created (alist-get 'CREATED (vulpea-note-properties n)))
                     (time-str (if (and created (string-match "\\([0-9]+:[0-9]+\\)" created))
                                   (match-string 1 created)
                                 "     "))

--- a/vulpea-journal.el
+++ b/vulpea-journal.el
@@ -183,7 +183,7 @@ Falls back to CREATED property if file path doesn't contain a date."
       (or (vulpea-journal--date-from-file path)
           ;; Fall back to CREATED property
           (let* ((props (vulpea-note-properties note))
-                 (created (cdr (assoc "CREATED" props))))
+                 (created (alist-get 'CREATED props)))
             (vulpea-journal--debug "note-date: fallback to props=%S created=%S"
                                    props created)
             (when (and created


### PR DESCRIPTION
Closes #9

`json-parse-string` with `:object-type 'alist` returns symbol keys, but the created-today widget looks up CREATED using string keys via `(cdr (assoc "CREATED" ...))`, which always returns `nil`.

Replace with `(alist-get 'CREATED ...)` in all four affected locations.

## Changes

- `vulpea-journal.el:186` — fallback date extraction
- `vulpea-journal-ui.el:206,208` — sort comparator
- `vulpea-journal-ui.el:409` — time display
- `test/vulpea-journal-test.el` — new test covering the query and property lookup

## Test plan

- [x] `eldev test` — 15/15 passing
- [x] Verified `json-parse-string` returns symbol keys on both Emacs 29 and 30