### PR TITLE
fix: highlight selected calendar day without requiring hl-line

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -16,6 +16,7 @@
 
 ** Fixed
 
+- Fix selected day not being highlighted in the calendar widget when the optional =hl-line= library is not loaded. =vulpea-journal-ui-calendar-selected= now inherits from the always-available =highlight= face instead of =hl-line=. ([[https://github.com/d12frosted/vulpea-journal/issues/14][#14]])
 - Fix outdated =vulpea-db-sync= references in README — the function was renamed to =vulpea-db-sync-full-scan= in vulpea. ([[https://github.com/d12frosted/vulpea-journal/issues/11][#11]])
 - Fix journal entries not found after database rebuild (=vulpea-db-sync-full-scan=). Root cause: when =vulpea-db-sync-directories= contains =~= paths (e.g., =~/notes=), the sync stored them unexpanded in the database while the journal always expanded them (e.g., =/home/user/notes=), causing exact-match lookups to fail. Fixed in vulpea by expanding paths in =vulpea-db-sync--list-org-files=. Also adds =abbreviate-file-name= and =file-truename= fallbacks in =vulpea-journal-find-note= for defense-in-depth. ([[https://github.com/d12frosted/vulpea-journal/issues/5][#5]])
 - Fix stale database connections in tests by properly closing connections between test runs.

--- a/vulpea-journal-ui.el
+++ b/vulpea-journal-ui.el
@@ -150,9 +150,12 @@ These days are also marked with a dot (·) indicator."
   :group 'vulpea-journal-ui)
 
 (defface vulpea-journal-ui-calendar-selected
-  '((t :inherit hl-line))
+  '((t :inherit highlight))
   "Face for the currently selected day in the calendar widget.
-This is the date of the journal entry you are currently viewing."
+This is the date of the journal entry you are currently viewing.
+Inherits from `highlight' (defined in faces.el, always loaded)
+rather than `hl-line', which is only defined once the optional
+hl-line library is loaded."
   :group 'vulpea-journal-ui)
 
 


### PR DESCRIPTION
Closes #14.

`vulpea-journal-ui-calendar-selected` inherited from the `hl-line` face, but `vulpea-journal-ui` never loads the `hl-line` library. `hl-line` ships with Emacs, but its face is only defined once the library is loaded — so configurations that never `require` it left the selected day in the calendar widget unhighlighted.

This changes the face to inherit from `highlight` instead, which is defined in `faces.el` and therefore always available. This fixes the highlight without adding an `hl-line` dependency just for one face.