### PR TITLE
fix: pass template :body for heading-level journal entries

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -16,6 +16,7 @@
 
 ** Fixed
 
+- Fix =:body= from monthly templates being silently dropped for heading-level entries. =vulpea-journal--create-heading-note= now passes the template =:body= through to =vulpea-create=, matching the file-level (daily) path. ([[https://github.com/d12frosted/vulpea-journal/issues/16][#16]])
 - Fix selected day not being highlighted in the calendar widget when the optional =hl-line= library is not loaded. =vulpea-journal-ui-calendar-selected= now inherits from the always-available =highlight= face instead of =hl-line=. ([[https://github.com/d12frosted/vulpea-journal/issues/14][#14]])
 - Fix outdated =vulpea-db-sync= references in README — the function was renamed to =vulpea-db-sync-full-scan= in vulpea. ([[https://github.com/d12frosted/vulpea-journal/issues/11][#11]])
 - Fix journal entries not found after database rebuild (=vulpea-db-sync-full-scan=). Root cause: when =vulpea-db-sync-directories= contains =~= paths (e.g., =~/notes=), the sync stored them unexpanded in the database while the journal always expanded them (e.g., =/home/user/notes=), causing exact-match lookups to fail. Fixed in vulpea by expanding paths in =vulpea-db-sync--list-org-files=. Also adds =abbreviate-file-name= and =file-truename= fallbacks in =vulpea-journal-find-note= for defense-in-depth. ([[https://github.com/d12frosted/vulpea-journal/issues/5][#5]])

--- a/test/vulpea-journal-test.el
+++ b/test/vulpea-journal-test.el
@@ -417,6 +417,23 @@ after a full scan rebuild."
         ;; Should have journal tag
         (should (vulpea-journal-note-p note))))))
 
+(ert-deftest vulpea-journal-monthly-create-note-with-body ()
+  "Test monthly heading entry includes :body from template."
+  (vulpea-test--with-temp-db
+    (let* ((vulpea-journal-default-template
+            (vulpea-journal-template-monthly
+             :body "Morning thoughts go here."))
+           (date (encode-time 0 0 12 25 11 2024)))
+      (let ((note (vulpea-journal-note date)))
+        (should note)
+        ;; Heading entry should be at entry-level (1)
+        (should (= (vulpea-note-level note) 1))
+        ;; The :body from the template must be written into the entry
+        (with-temp-buffer
+          (insert-file-contents (vulpea-note-path note))
+          (should (string-match-p "Morning thoughts go here\\."
+                                  (buffer-string))))))))
+
 (ert-deftest vulpea-journal-monthly-find-note ()
   "Test finding a monthly journal note by date."
   (vulpea-test--with-temp-db

--- a/vulpea-journal.el
+++ b/vulpea-journal.el
@@ -419,6 +419,7 @@ an ID property and running `vulpea-db-sync-full-scan'" file))
      entry-title
      nil
      :parent container
+     :body (plist-get tpl :body)
      :properties `(("CREATED" . ,date-str))
      :after 'last)))
 


### PR DESCRIPTION
Monthly (heading-level) journal entries silently dropped the template `:body`. If you set `:body` on `vulpea-journal-template-monthly`, the content never landed in the new day heading - you just got an empty heading with a property drawer.

The cause is small: `vulpea-journal--create-heading-note` never forwarded `:body` to `vulpea-create`, while its file-level sibling `vulpea-journal--create-file-note` always did. The fix passes `:body (plist-get tpl :body)` through, so the heading path matches the daily path.

Worth noting this is entirely on the vulpea-journal side - `vulpea-create` has supported (and tested) `:body` for heading-level notes all along, so nothing changes in vulpea.

Refs #16 (the `:body` drop specifically; the nesting / `:entry-level` discussion in that thread is a separate concern).
