### PR TITLE
feat: nest monthly journal entries under date-derived group headings

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -10,6 +10,7 @@
 
 - New =vulpea-journal-tag= customization variable for configuring the journal tag. Template builders use it as the default, and =vulpea-journal-note-p= checks against it directly. ([[https://github.com/d12frosted/vulpea-journal/pull/12][#12]])
 - Monthly journal granularity: one file per month with daily entries as headings. Use =vulpea-journal-template-monthly= to create a monthly template. ([[https://github.com/d12frosted/vulpea-journal/issues/2][#2]])
+- Monthly templates can nest daily entries under date-derived grouping headings via the new =:entry-groups= key of =vulpea-journal-template-monthly=. Each element (a strftime string such as ="week %V"= or a function of the date) adds one heading level between the file and the entry; group headings are created and reused on demand, and =:entry-level= is derived from the number of groups so lookup and creation agree. ([[https://github.com/d12frosted/vulpea-journal/issues/16][#16]])
 - Template builder functions: =vulpea-journal-template-daily= and =vulpea-journal-template-monthly= with sensible defaults and override support.
 - Active date tracking for sidebar widgets, ensuring correct behavior when navigating between entries in the same file.
 - Migration script now adds journal filetag to migrated files using =vulpea-buffer-tags-add=. ([[https://github.com/d12frosted/vulpea-journal/pull/12][#12]])

--- a/README.org
+++ b/README.org
@@ -179,9 +179,40 @@ Monthly template parameters:
 |-----------------+--------------------+----------------------------------|
 | =:file-name=    | =journal/%Y-%m.org= | strftime format for monthly file |
 | =:title=        | =%Y-%m=             | File-level note title            |
-| =:entry-level=  | =1=                 | Heading level for daily entries  |
+| =:entry-level=  | =1=                 | Heading level for daily entries (derived when =:entry-groups= is set) |
 | =:entry-title=  | =%d %A=             | strftime format for heading      |
+| =:entry-groups= | =nil=               | Optional grouping headings (see below) |
 | =:tags=         | =("journal")=       | Tags (first one identifies journals) |
+
+By default, daily entries are placed directly under the monthly file. To nest them under intermediate grouping headings (for example, one heading per ISO week), use =:entry-groups=:
+
+#+begin_src emacs-lisp
+(setq vulpea-journal-default-template
+      (vulpea-journal-template-monthly
+       :entry-title  "%d %A"
+       :entry-groups '("week %V")
+       :body         "*** Tasks\n\n*** Notes\n"))
+#+end_src
+
+Each element of =:entry-groups= adds one heading level between the file and the daily entry. An element is either a =strftime= format string (expanded for the entry's date) or a function of one argument (the date) returning the heading title. A single spec may be given without wrapping it in a list. Group headings are created on demand and reused across days that resolve to the same title, and =:entry-level= is derived as =1 + (length entry-groups)= so lookup and creation stay in sync. The template above produces:
+
+#+begin_example
+#+title: 2026-06
+#+filetags: :journal:
+* week 24
+** 08 Monday
+*** Tasks
+*** Notes
+** 09 Tuesday
+*** Tasks
+*** Notes
+* week 25
+** 15 Monday
+*** Tasks
+*** Notes
+#+end_example
+
+Because =:body= is inserted verbatim at fixed heading levels, nest its subheadings one level below the entry (=***= for entries at level 2, as above).
 
 *** Raw template plist
 

--- a/test/vulpea-journal-test.el
+++ b/test/vulpea-journal-test.el
@@ -367,6 +367,19 @@ after a full scan rebuild."
     (should (equal (plist-get tpl :entry-title) "%d %A"))
     (should (equal (plist-get tpl :tags) '("journal" "monthly")))))
 
+(ert-deftest vulpea-journal-template-monthly-entry-groups ()
+  "Test monthly builder derives entry-level from :entry-groups."
+  ;; A list of group specs sets entry-level to 1 + number of groups.
+  (let ((tpl (vulpea-journal-template-monthly
+              :entry-groups '("week %V"))))
+    (should (equal (plist-get tpl :entry-groups) '("week %V")))
+    (should (= (plist-get tpl :entry-level) 2)))
+  ;; A bare string spec is normalized to a single-element list.
+  (let ((tpl (vulpea-journal-template-monthly
+              :entry-groups "week %V")))
+    (should (equal (plist-get tpl :entry-groups) '("week %V")))
+    (should (= (plist-get tpl :entry-level) 2))))
+
 ;;; Template Helper Tests
 
 (ert-deftest vulpea-journal-heading-entry-p-daily ()
@@ -433,6 +446,76 @@ after a full scan rebuild."
           (insert-file-contents (vulpea-note-path note))
           (should (string-match-p "Morning thoughts go here\\."
                                   (buffer-string))))))))
+
+(ert-deftest vulpea-journal-monthly-nested-under-groups ()
+  "Test daily entries nest under date-derived group headings."
+  (vulpea-test--with-temp-db
+    (let* ((vulpea-journal-default-template
+            (vulpea-journal-template-monthly
+             :entry-groups '("week %V")
+             :entry-title "%d %A"))
+           ;; week 24: Mon and Tue; week 25: Mon
+           (d1 (encode-time 0 0 12 8 6 2026))
+           (d2 (encode-time 0 0 12 9 6 2026))
+           (d3 (encode-time 0 0 12 15 6 2026)))
+      (let ((n1 (vulpea-journal-note d1))
+            (n2 (vulpea-journal-note d2))
+            (n3 (vulpea-journal-note d3)))
+        ;; Entries live at level 2 (under a level-1 week heading)
+        (should (= (vulpea-note-level n1) 2))
+        (should (= (vulpea-note-level n2) 2))
+        (should (= (vulpea-note-level n3) 2))
+        ;; Same ISO week -> same week heading (same outline path)
+        (should (equal (vulpea-note-outline-path n1)
+                       (vulpea-note-outline-path n2)))
+        (should (equal (vulpea-note-outline-path n1) '("week 24")))
+        ;; Different ISO week -> different week heading
+        (should (equal (vulpea-note-outline-path n3) '("week 25")))
+        ;; Week headings are reused, not duplicated: exactly two at level 1
+        (should (= (length (vulpea-db-query-by-file-path
+                            (vulpea-note-path n1) 1))
+                   2))
+        ;; Grouping headings carry no date, so they never show up as
+        ;; journal entries: all-dates lists the three days only.
+        (should (= (length (vulpea-journal-all-dates)) 3))
+        ;; Entries remain findable by date after nesting
+        (should (string= (vulpea-note-id (vulpea-journal-find-note d1))
+                         (vulpea-note-id n1)))
+        (should (string= (vulpea-note-id (vulpea-journal-find-note d2))
+                         (vulpea-note-id n2)))
+        (should (string= (vulpea-note-id (vulpea-journal-find-note d3))
+                         (vulpea-note-id n3)))))))
+
+(ert-deftest vulpea-journal-monthly-nested-multi-level ()
+  "Test entries nest under a multi-level :entry-groups chain."
+  (vulpea-test--with-temp-db
+    (let* ((vulpea-journal-default-template
+            (vulpea-journal-template-monthly
+             :entry-groups '("%Y" "week %V")
+             :entry-title "%d %A"))
+           (d1 (encode-time 0 0 12 8 6 2026))    ; week 24
+           (d2 (encode-time 0 0 12 15 6 2026)))  ; week 25
+      ;; entry-level is derived as 1 + 2 groups = 3
+      (should (= (plist-get vulpea-journal-default-template :entry-level) 3))
+      (let ((n1 (vulpea-journal-note d1))
+            (n2 (vulpea-journal-note d2)))
+        (should (= (vulpea-note-level n1) 3))
+        (should (= (vulpea-note-level n2) 3))
+        ;; Both under the same year heading, different week headings
+        (should (equal (vulpea-note-outline-path n1) '("2026" "week 24")))
+        (should (equal (vulpea-note-outline-path n2) '("2026" "week 25")))
+        ;; One shared year heading at level 1, two week headings at level 2
+        (should (= (length (vulpea-db-query-by-file-path
+                            (vulpea-note-path n1) 1))
+                   1))
+        (should (= (length (vulpea-db-query-by-file-path
+                            (vulpea-note-path n1) 2))
+                   2))
+        ;; Entries remain findable by date
+        (should (string= (vulpea-note-id (vulpea-journal-find-note d1))
+                         (vulpea-note-id n1)))
+        (should (string= (vulpea-note-id (vulpea-journal-find-note d2))
+                         (vulpea-note-id n2)))))))
 
 (ert-deftest vulpea-journal-monthly-find-note ()
   "Test finding a monthly journal note by date."

--- a/vulpea-journal.el
+++ b/vulpea-journal.el
@@ -137,6 +137,17 @@ Or as a function for dynamic configuration:
 
 ;;; Template Builders
 
+(defun vulpea-journal--normalize-groups (groups)
+  "Normalize GROUPS into a list of group specs.
+GROUPS may be nil, a single spec (a strftime string or a function
+of one argument DATE), or a list of such specs.  A single spec is
+wrapped in a one-element list."
+  (cond
+   ((null groups) nil)
+   ((or (stringp groups) (functionp groups)) (list groups))
+   ((listp groups) groups)
+   (t (error "Invalid :entry-groups value: %S" groups))))
+
 (cl-defun vulpea-journal-template-daily (&key
                                          (file-name "journal/%Y-%m-%d.org")
                                          (title "%Y-%m-%d %A")
@@ -165,6 +176,7 @@ All parameters are optional with sensible defaults:
                                            (tags (list vulpea-journal-tag))
                                            (entry-level 1)
                                            (entry-title "%d %A")
+                                           entry-groups
                                            head body properties meta context)
   "Create a monthly journal template (one file per month).
 
@@ -176,17 +188,30 @@ All parameters are optional with sensible defaults:
 - FILE-NAME: strftime format for monthly file (default: journal/%Y-%m.org)
 - TITLE: strftime format for file-level title (default: %Y-%m)
 - TAGS: list of tags (default: (\"journal\"))
-- ENTRY-LEVEL: heading level for daily entries (default: 1)
+- ENTRY-LEVEL: heading level for daily entries (default: 1).  Ignored
+  when ENTRY-GROUPS is set, in which case it is derived (see below).
 - ENTRY-TITLE: strftime format for entry heading (default: %d %A)
+- ENTRY-GROUPS: optional grouping headings that nest the daily entry
+  deeper inside the file.  Each element produces one heading level
+  between the file and the entry and is either a strftime format
+  string (e.g. \"week %V\") or a function of one argument (DATE)
+  returning the heading title.  A single spec may be given without
+  wrapping it in a list.  When set, ENTRY-LEVEL is derived as
+  1 + number of groups so lookup and creation agree.  For example,
+  :entry-groups \\='(\"week %V\") nests each day under a \"week NN\"
+  heading and entries live at level 2.
 - HEAD, BODY, PROPERTIES, META, CONTEXT: passed to `vulpea-create'"
-  (append
-   (list :file-name file-name :title title :tags tags
-         :entry-level entry-level :entry-title entry-title)
-   (when head (list :head head))
-   (when body (list :body body))
-   (when properties (list :properties properties))
-   (when meta (list :meta meta))
-   (when context (list :context context))))
+  (let* ((groups (vulpea-journal--normalize-groups entry-groups))
+         (entry-level (if groups (1+ (length groups)) entry-level)))
+    (append
+     (list :file-name file-name :title title :tags tags
+           :entry-level entry-level :entry-title entry-title)
+     (when groups (list :entry-groups groups))
+     (when head (list :head head))
+     (when body (list :body body))
+     (when properties (list :properties properties))
+     (when meta (list :meta meta))
+     (when context (list :context context)))))
 
 
 ;;; Template Resolution
@@ -406,19 +431,66 @@ an ID property and running `vulpea-db-sync-full-scan'" file))
      :context (plist-get tpl :context))
     (vulpea-db-get-by-id id)))
 
+(defun vulpea-journal--resolve-group-title (spec date)
+  "Resolve group SPEC to a heading title for DATE.
+SPEC is either a strftime format string or a function of one
+argument (DATE) returning a string."
+  (cond
+   ((functionp spec) (funcall spec date))
+   ((stringp spec) (format-time-string spec date))
+   (t (error "Invalid :entry-groups spec: %S" spec))))
+
+(defun vulpea-journal--find-child-heading (file level title outline-path)
+  "Find heading note in FILE at LEVEL titled TITLE under OUTLINE-PATH.
+OUTLINE-PATH is the expected ancestor heading titles, outermost
+first.  Returns the matching `vulpea-note' or nil."
+  (--first
+   (and (string= (vulpea-note-title it) title)
+        (equal (vulpea-note-outline-path it) outline-path))
+   (vulpea-journal--query-file-notes file level)))
+
+(defun vulpea-journal--ensure-group-path (container date groups)
+  "Ensure the chain of GROUPS headings under CONTAINER for DATE.
+CONTAINER is the file-level container `vulpea-note'.  GROUPS is a
+list of group specs (see `vulpea-journal--resolve-group-title').
+Missing group headings are created on demand and existing ones are
+reused.  Returns the deepest container note that should parent the
+entry, which is CONTAINER itself when GROUPS is empty."
+  (let ((parent container)
+        (file (vulpea-note-path container))
+        (ancestry nil))
+    (dolist (spec (vulpea-journal--normalize-groups groups) parent)
+      (let* ((title (vulpea-journal--resolve-group-title spec date))
+             (level (1+ (vulpea-note-level parent)))
+             (existing (vulpea-journal--find-child-heading
+                        file level title (reverse ancestry))))
+        ;; Group headings carry no :tags and no CREATED property of
+        ;; their own; they inherit the file's filetags structurally,
+        ;; so date lookup never confuses them with daily entries.
+        (setq parent (or existing
+                         (vulpea-create title nil
+                                        :parent parent
+                                        :after 'last)))
+        (push title ancestry)))))
+
 (defun vulpea-journal--create-heading-note (date tpl)
-  "Create a heading-level journal note for DATE using template TPL."
+  "Create a heading-level journal note for DATE using template TPL.
+When TPL has a non-nil :entry-groups, the entry is nested under the
+chain of date-derived grouping headings (created on demand)."
   (let* ((file (vulpea-journal--file-for-date date))
          (entry-title (vulpea-journal--entry-title-for-date date))
          (date-str (format-time-string "[%Y-%m-%d]" date))
-         ;; Find or create the container (file-level note)
-         (container (vulpea-journal--ensure-container file date tpl)))
-    ;; Create heading entry under container
+         ;; Find or create the container (file-level note), then walk
+         ;; the optional chain of grouping headings for this date.
+         (container (vulpea-journal--ensure-container file date tpl))
+         (parent (vulpea-journal--ensure-group-path
+                  container date (plist-get tpl :entry-groups))))
+    ;; Create heading entry under the deepest container.
     ;; Note: no :tags here - headings inherit filetags from container
     (vulpea-create
      entry-title
      nil
-     :parent container
+     :parent parent
      :body (plist-get tpl :body)
      :properties `(("CREATED" . ,date-str))
      :after 'last)))


### PR DESCRIPTION
Follow-up to #16: monthly journal entries could not be nested under intermediate headings. If you wanted days grouped under weekly headings, there was no way to express it - entries always landed at the top level, appended at the bottom of the file. Worse, a manual `:entry-level 2` was honored when *looking up* an entry but ignored when *creating* one, so the two disagreed and you could end up with duplicates.

This adds an `:entry-groups` key to `vulpea-journal-template-monthly`. Each element inserts one heading level between the monthly file and the daily entry, and is either a strftime string (e.g. `"week %V"`) or a function of the date returning the heading title. A single spec needn't be wrapped in a list. Group headings are created on demand and reused across days that resolve to the same title, and `:entry-level` is derived as `1 + (length entry-groups)` so lookup and creation stay in sync. It composes - `'("%Y" "week %V")` nests day under week under year.

Example:

```elisp
(vulpea-journal-template-monthly
 :entry-title  "%d %A"
 :entry-groups '("week %V")
 :body         "*** Tasks\n\n*** Notes\n")
```

produces one `* week NN` heading per ISO week with each day as a `**` child (and, since `:body` is inserted at fixed levels, its subheadings sit at `***`).

This is all on the vulpea-journal side - vulpea's `vulpea-create` already accepts any note as `:parent`, which is what makes the nesting possible. README and CHANGELOG updated.

Refs #16
