### PR TITLE
Add keybindings when inputting dates with vulpea-journal-date

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,7 +15,7 @@
 - Template builder functions: =vulpea-journal-template-daily= and =vulpea-journal-template-monthly= with sensible defaults and override support.
 - Active date tracking for sidebar widgets, ensuring correct behavior when navigating between entries in the same file.
 - Migration script now adds journal filetag to migrated files using =vulpea-buffer-tags-add=. ([[https://github.com/d12frosted/vulpea-journal/pull/12][#12]])
-- Added keybindings =M-<left>= and =M-<right>= to navigate between dates with existing journal entries in =vulpea-journal-date=.
+- Added keybindings =M-<left>= and =M-<right>= to navigate between dates with existing journal entries in =vulpea-journal-date=. ([[https://github.com/d12frosted/vulpea-journal/issues/23][#23]])
 
 ** Fixed
 

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,6 +15,7 @@
 - Template builder functions: =vulpea-journal-template-daily= and =vulpea-journal-template-monthly= with sensible defaults and override support.
 - Active date tracking for sidebar widgets, ensuring correct behavior when navigating between entries in the same file.
 - Migration script now adds journal filetag to migrated files using =vulpea-buffer-tags-add=. ([[https://github.com/d12frosted/vulpea-journal/pull/12][#12]])
+- Added keybindings =M-<left>= and =M-<right>= to navigate between dates with existing journal entries in =vulpea-journal-date=.
 
 ** Fixed
 

--- a/README.org
+++ b/README.org
@@ -333,6 +333,8 @@ Reference orders for vulpea-ui widgets: stats=100, outline=200, backlinks=300, l
 | =vulpea-journal-previous= | Go to previous journal entry                            |
 | =vulpea-journal-setup=    | Enable calendar/sidebar integration and register widgets |
 
+*Note*: When using =vulpea-journal-date= to input a date, you can leverage standard Org-mode keybindings for navigating between days (refer to the =org-read-date= documentation for details). Additionally, =M-<left>= and =M-<right>= allow you to move specifically through days that already have journal entries.
+
 * Sidebar Keybindings
 
 When viewing a journal note, the sidebar provides quick navigation:

--- a/vulpea-journal.el
+++ b/vulpea-journal.el
@@ -668,9 +668,9 @@ When called interactively, prompt for date."
   (minibuffer-with-setup-hook
       (lambda ()
         (local-set-key
-         (kbd "M-<left>") #'vulpea-journal-not-in-calendar-previous)
+         (kbd "M-<left>") #'vulpea-journal-date-previous)
         (local-set-key
-         (kbd "M-<right>") #'vulpea-journal-not-in-calendar-next))
+         (kbd "M-<right>") #'vulpea-journal-date-next))
 
     ;; Code below is exactly the same as the original vulpea-journal--read-date function
     (let* ((org-read-date-prefer-future nil)
@@ -803,22 +803,15 @@ Falls back to `org-eval-in-calendar' on Org < 9.8."
                                     (decoded-time-year decoded))))
       (message "No previous journal entry"))))
 
-(defun vulpea-journal-not-in-calendar-previous ()
-  "Move to previous journal entry in calendar.
-
-  This is the same as `vulpea-journal-calendar-previous', with the
-  difference that `vulpea-journal-calendar-previous' must be called from
-  the calendar buffer, while this one can be called from another buffer."
+(defun vulpea-journal-date-previous ()
+  "Move to the previous date that has a journal entry.
+Intended for use while reading a date with `vulpea-journal-date'."
   (interactive)
   (vulpea-journal--funcall-in-calendar #'vulpea-journal-calendar-previous))
 
-
-(defun vulpea-journal-not-in-calendar-next ()
-  "Move to next journal entry in calendar.
-
-  This is the same as `vulpea-journal-calendar-next', with the
-  difference that `vulpea-journal-calendar-next' must be called from the
-  calendar buffer, while this one can be called from another buffer."
+(defun vulpea-journal-date-next ()
+  "Move to the next date that has a journal entry.
+Intended for use while reading a date with `vulpea-journal-date'."
   (interactive)
   (vulpea-journal--funcall-in-calendar #'vulpea-journal-calendar-next))
 

--- a/vulpea-journal.el
+++ b/vulpea-journal.el
@@ -759,6 +759,8 @@ Marks entries for all visible months (previous, current, next)."
 (defun vulpea-journal--funcall-in-calendar (fn)
   "Call FN in the calendar window during `org-read-date'.
 Falls back to `org-eval-in-calendar' on Org < 9.8."
+  (unless (get-buffer-window calendar-buffer t)
+    (user-error "Only available while reading a date"))
   (if (fboundp 'org-funcall-in-calendar)
       (org-funcall-in-calendar fn)
     (with-no-warnings (org-eval-in-calendar (list 'funcall fn)))))

--- a/vulpea-journal.el
+++ b/vulpea-journal.el
@@ -665,9 +665,17 @@ When called interactively, prompt for date."
 
 (defun vulpea-journal--read-date (prompt)
   "Read a date from user with PROMPT."
-  (let* ((org-read-date-prefer-future nil)
-         (date-string (org-read-date nil nil nil prompt)))
-    (org-time-string-to-time date-string)))
+  (minibuffer-with-setup-hook
+      (lambda ()
+        (local-set-key
+         (kbd "M-<left>") #'vulpea-journal-not-in-calendar-previous)
+        (local-set-key
+         (kbd "M-<right>") #'vulpea-journal-not-in-calendar-next))
+
+    ;; Code below is exactly the same as the original vulpea-journal--read-date function
+    (let* ((org-read-date-prefer-future nil)
+           (date-string (org-read-date nil nil nil prompt)))
+      (org-time-string-to-time date-string))))
 
 (defun vulpea-journal--buffer-note ()
   "Get the journal note for the current buffer.
@@ -748,6 +756,13 @@ Marks entries for all visible months (previous, current, next)."
                (list month day year)
                'vulpea-journal-calendar-entry-face))))))))
 
+(defun vulpea-journal--funcall-in-calendar (fn)
+  "Call FN in the calendar window during `org-read-date'.
+Falls back to `org-eval-in-calendar' on Org < 9.8."
+  (if (fboundp 'org-funcall-in-calendar)
+      (org-funcall-in-calendar fn)
+    (with-no-warnings (org-eval-in-calendar (list 'funcall fn)))))
+
 (defun vulpea-journal-calendar-open ()
   "Open journal for date at point in calendar."
   (interactive)
@@ -788,6 +803,24 @@ Marks entries for all visible months (previous, current, next)."
                                     (decoded-time-year decoded))))
       (message "No previous journal entry"))))
 
+(defun vulpea-journal-not-in-calendar-previous ()
+  "Move to previous journal entry in calendar.
+
+  This is the same as `vulpea-journal-calendar-previous', with the
+  difference that `vulpea-journal-calendar-previous' must be called from
+  the calendar buffer, while this one can be called from another buffer."
+  (interactive)
+  (vulpea-journal--funcall-in-calendar #'vulpea-journal-calendar-previous))
+
+
+(defun vulpea-journal-not-in-calendar-next ()
+  "Move to next journal entry in calendar.
+
+  This is the same as `vulpea-journal-calendar-next', with the
+  difference that `vulpea-journal-calendar-next' must be called from the
+  calendar buffer, while this one can be called from another buffer."
+  (interactive)
+  (vulpea-journal--funcall-in-calendar #'vulpea-journal-calendar-next))
 
 ;;; Calendar Minor Mode
 


### PR DESCRIPTION
Add `M-<left>` and `M-<right>` keybindings to navigate between dates with existing journal entries in `vulpea-journal-date`.

Implement changes discussed in #23.