### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,8 @@
 
 * Unreleased
 
+* v1.1.0 (2026-07-01)
+
 ** Breaking Changes
 
 - Replaced =vulpea-directory= with =vulpea-default-notes-directory= for journal file path resolution. If you previously set =vulpea-directory=, use =vulpea-default-notes-directory= instead (which defaults to the first entry in =vulpea-db-sync-directories=).

--- a/vulpea-journal.el
+++ b/vulpea-journal.el
@@ -5,7 +5,7 @@
 ;;
 ;; Author: Boris Buliga <boris@d12frosted.io>
 ;; Maintainer: Boris Buliga <boris@d12frosted.io>
-;; Version: 1.0.1
+;; Version: 1.1.0
 ;; Package-Requires: ((emacs "29.1") (vulpea "2.0.0") (vulpea-ui "1.0.0") (dash "2.20.0"))
 ;; Keywords: org-mode, roam, convenience
 ;; URL: https://github.com/d12frosted/vulpea-journal


### PR DESCRIPTION
Cuts **v1.1.0** — our first release since v1.0.1 back in January, so it's a chunky one. 26 commits of features and fixes finally getting a version number.

This PR itself just does the release mechanics: bumps the `Version:` header in `vulpea-journal.el` and rolls the `Unreleased` changelog section into `v1.1.0 (2026-07-01)`.

What's in the release:

- Monthly journal granularity — one file per month, days as headings — plus nested entry groups and per-entry aliases
- Date navigation with `M-<left>` / `M-<right>` in `vulpea-journal-date` (#23)
- New `vulpea-journal-tag` variable for identifying journal notes
- A pile of template fixes: `:body`, `:properties` and `:context` were silently dropped for heading-level entries (#16)
- The nasty `~`-path lookup failure after a DB rebuild is gone (#5)

One breaking change: `vulpea-directory` is replaced by `vulpea-default-notes-directory`. Migration is a one-liner and it's spelled out in the changelog.

Full details in [CHANGELOG.org](CHANGELOG.org). Contributor shout-outs will go in the GitHub release notes.