### PR TITLE
Bump vulpea and vulpea-ui, declare vui explicitly

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,10 @@
 
 * Unreleased
 
+** Changed
+
+- Bump minimum dependency versions to =vulpea= 2.5.0 and =vulpea-ui= 1.1.0. Also declare =vui= 1.3.0 explicitly in =Package-Requires=: =vulpea-journal-ui= requires it directly (=vui-defcomponent=, =vui-button=, etc.), so it should not be relied on as a transitive dependency of =vulpea-ui=.
+
 * v1.1.0 (2026-07-01)
 
 ** Breaking Changes

--- a/vulpea-journal.el
+++ b/vulpea-journal.el
@@ -6,7 +6,7 @@
 ;; Author: Boris Buliga <boris@d12frosted.io>
 ;; Maintainer: Boris Buliga <boris@d12frosted.io>
 ;; Version: 1.1.0
-;; Package-Requires: ((emacs "29.1") (vulpea "2.0.0") (vulpea-ui "1.0.0") (dash "2.20.0"))
+;; Package-Requires: ((emacs "29.1") (vulpea "2.5.0") (vulpea-ui "1.1.0") (vui "1.3.0") (dash "2.20.0"))
 ;; Keywords: org-mode, roam, convenience
 ;; URL: https://github.com/d12frosted/vulpea-journal
 ;;


### PR DESCRIPTION
Bumps the minimum deps to match latest master:

- `vulpea` 2.0.0 → 2.5.0
- `vulpea-ui` 1.0.0 → 1.1.0

Also adds `vui` 1.3.0 to `Package-Requires`. It was already required directly in `vulpea-journal-ui` (`vui-defcomponent`, `vui-button`, `vui-set-state`, …) but only resolved transitively through vulpea-ui, so this just makes the dependency honest. vulpea-ui 1.1.0 pins vui 1.3.0 anyway.