### PR TITLE
chore: release v1.1.1

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,8 @@
 
 * Unreleased
 
+* v1.1.1 (2026-07-03)
+
 ** Changed
 
 - Bump minimum dependency versions to =vulpea= 2.5.0 and =vulpea-ui= 1.1.0. Also declare =vui= 1.3.0 explicitly in =Package-Requires=: =vulpea-journal-ui= requires it directly (=vui-defcomponent=, =vui-button=, etc.), so it should not be relied on as a transitive dependency of =vulpea-ui=.

--- a/vulpea-journal.el
+++ b/vulpea-journal.el
@@ -5,7 +5,7 @@
 ;;
 ;; Author: Boris Buliga <boris@d12frosted.io>
 ;; Maintainer: Boris Buliga <boris@d12frosted.io>
-;; Version: 1.1.0
+;; Version: 1.1.1
 ;; Package-Requires: ((emacs "29.1") (vulpea "2.5.0") (vulpea-ui "1.1.0") (vui "1.3.0") (dash "2.20.0"))
 ;; Keywords: org-mode, roam, convenience
 ;; URL: https://github.com/d12frosted/vulpea-journal


### PR DESCRIPTION
Cuts v1.1.1. It's purely the dependency-floor bump from #27 (`vulpea` 2.5.0, `vulpea-ui` 1.1.0, and `vui` 1.3.0 now declared explicitly) with no code changes.

vulpea 2.5.0, vulpea-ui 1.2.0, and vui 1.3.0 are all live on MELPA Stable now, so once this is tagged, stable can build against the new floors.

Version header → 1.1.1, changelog `Unreleased` → v1.1.1.