### PR TITLE
Fix visiting note through previous years not setting active date

### DIFF
--- a/vulpea-journal-ui.el
+++ b/vulpea-journal-ui.el
@@ -466,7 +466,7 @@ ON-SELECT is callback to handle date selection."
          (visit-note (lambda ()
                        (let ((main-win (vulpea-ui--get-main-window)))
                          (when main-win (select-window main-win))
-                         (vulpea-visit note)))))
+                         (vulpea-journal-ui--visit-date date)))))
     (vui-vstack
      (vui-hstack
       :spacing 1


### PR DESCRIPTION
Hi @d12frosted , just a simple bug fix. Previously, visiting journal notes through the previous year entries in the sidebar with `vulpea-visit` does not set the activate date properly. This makes the side bar unable to refresh properly. I assume using `vulpea-journal-ui--visit-date` should be the desired behavior here. Tested on my machine.