### PR TITLE
chore: tidy previous-years visit code after #31

### DIFF
--- a/vulpea-journal-ui.el
+++ b/vulpea-journal-ui.el
@@ -464,9 +464,7 @@ ON-SELECT is callback to handle date selection."
          (toggle-expanded (lambda ()
                             (vui-set-state :expanded (not expanded))))
          (visit-note (lambda ()
-                       (let ((main-win (vulpea-ui--get-main-window)))
-                         (when main-win (select-window main-win))
-                         (vulpea-journal-ui--visit-date date)))))
+                       (vulpea-journal-ui--visit-date date))))
     (vui-vstack
      (vui-hstack
       :spacing 1


### PR DESCRIPTION
Drop the leftover window-selection wrapper: `vulpea-journal-ui--visit-date` already selects the main window via `vulpea-ui-visit-note`. 