### PR TITLE
feat: add org-capture target for journal notes

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,10 @@
 
 * Unreleased
 
+** Features
+
+- New =vulpea-journal-capture-target= function for capturing straight into the journal via =org-capture=, without opening the vulpea-ui sidebar. Use it as a =(function ...)= target in =org-capture-templates=. It creates today's note on demand (registering it in the database on the first capture of the day) and positions point so that =entry= captures append as a top-level heading for daily templates, or nest under the day's heading for monthly templates. Accepts an optional =DATE= argument to capture into a specific day. ([[https://github.com/d12frosted/vulpea-journal/issues/34][#34]])
+
 ** Fixed
 
 - Fix visiting a note from the Previous Years widget not setting the active date, which left the sidebar showing the old date. The widget now navigates via =vulpea-journal-ui--visit-date= like the rest of the sidebar. Thanks to [[https://github.com/drcxd][@drcxd]]. ([[https://github.com/d12frosted/vulpea-journal/pull/31][#31]])

--- a/README.org
+++ b/README.org
@@ -368,6 +368,48 @@ Days with journal entries are highlighted in the calendar.
 
 The minor mode is automatically enabled in calendar buffers. You can toggle it with =M-x vulpea-journal-calendar-mode= if needed.
 
+* Capture
+
+Sometimes you just want to jot something into today's note without the sidebar and its widgets popping up. =vulpea-journal-capture-target= is an =org-capture= target function for exactly that. It creates today's note on demand (so the first capture of the day also registers it in the vulpea database) and moves point into place. It never touches the vulpea-ui sidebar.
+
+Add a capture template that uses it as a =(function ...)= target:
+
+#+begin_src emacs-lisp
+(add-to-list 'org-capture-templates
+             '("j" "Journal" entry
+               (function vulpea-journal-capture-target)
+               "* %U %?"))
+#+end_src
+
+The same template works for both daily and monthly journals: the target reads your =vulpea-journal-default-template= and positions point accordingly.
+
+For a *daily* template (one file per day), an =entry= capture is appended as a new top-level heading at the end of today's file:
+
+#+begin_example
+#+title: 2026-07-23 Thursday
+#+filetags: :journal:
+* Morning thought
+* Evening thought
+#+end_example
+
+For a *monthly* template (one file per month, days as headings), the entry nests as a child of today's day heading, so you do not need to narrow to it yourself:
+
+#+begin_example
+#+title: 2026-07
+#+filetags: :journal:
+* 23 Thursday
+** First quick note
+** Second quick note
+#+end_example
+
+The function only positions point, so the capture =type= (=entry=, =item=, =plain=, ...) and the content come entirely from your template. It also accepts an optional =DATE= argument if you want to capture into a specific day instead of today.
+
+If you would rather just visit today's note and write in it directly (no capture buffer, still no sidebar), skip the template and call:
+
+#+begin_src emacs-lisp
+(vulpea-visit (vulpea-journal-note (current-time)))
+#+end_src
+
 * Widgets Reference
 
 ** vulpea-journal-widget-nav
@@ -594,6 +636,9 @@ Usage:
 ;; Note retrieval
 (vulpea-journal-note date)          ; Get/create journal for DATE
 (vulpea-journal-find-note date)     ; Find existing journal (no create)
+
+;; Capture
+(vulpea-journal-capture-target)     ; `org-capture' target: point in today's note
 
 ;; Queries
 (vulpea-journal-all-dates)          ; All dates with journals

--- a/test/vulpea-journal-test.el
+++ b/test/vulpea-journal-test.el
@@ -716,5 +716,73 @@ after a full scan rebuild."
           (should (string= (vulpea-note-id found)
                            (vulpea-note-id note))))))))
 
+;;; Capture Target Tests
+
+(require 'org-capture)
+
+(defun vulpea-journal-test--file-contents (file)
+  "Return current contents of FILE, saving any live buffer first."
+  (let ((buf (get-file-buffer file)))
+    (when (and buf (buffer-modified-p buf))
+      (with-current-buffer buf (save-buffer))))
+  (with-temp-buffer
+    (insert-file-contents file)
+    (buffer-string)))
+
+(ert-deftest vulpea-journal-capture-target-daily ()
+  "Daily capture lands as a top-level heading in the day's file."
+  (vulpea-test--with-temp-db
+    (let* ((vulpea-journal-default-template (vulpea-journal-template-daily))
+           (date (encode-time 0 0 12 25 11 2024))
+           (org-capture-templates
+            `(("j" "Journal" entry
+               (function ,(lambda () (vulpea-journal-capture-target date)))
+               "* CAPTURED DAILY"
+               :immediate-finish t))))
+      (org-capture nil "j")
+      (let ((content (vulpea-journal-test--file-contents
+                      (vulpea-journal--file-for-date date))))
+        ;; Appended as a top-level heading (not nested).
+        (should (string-match-p "^\\* CAPTURED DAILY" content))))))
+
+(ert-deftest vulpea-journal-capture-target-monthly ()
+  "Monthly capture nests as a child of the day's heading."
+  (vulpea-test--with-temp-db
+    (let* ((vulpea-journal-default-template (vulpea-journal-template-monthly))
+           (date (encode-time 0 0 12 25 11 2024))
+           (org-capture-templates
+            `(("j" "Journal" entry
+               (function ,(lambda () (vulpea-journal-capture-target date)))
+               "* CAPTURED MONTHLY"
+               :immediate-finish t))))
+      (org-capture nil "j")
+      (let ((content (vulpea-journal-test--file-contents
+                      (vulpea-journal--file-for-date date))))
+        ;; Day heading at level 1, capture nested as its level-2 child.
+        (should (string-match-p "^\\* 25 Monday" content))
+        (should (string-match-p "^\\*\\* CAPTURED MONTHLY" content))
+        ;; The child must come after (below) the day heading.
+        (should (< (string-match "^\\* 25 Monday" content)
+                   (string-match "^\\*\\* CAPTURED MONTHLY" content)))))))
+
+(ert-deftest vulpea-journal-capture-target-creates-and-registers-note ()
+  "First capture of a day creates the note and registers it in the DB."
+  (vulpea-test--with-temp-db
+    (let* ((vulpea-journal-default-template (vulpea-journal-template-daily))
+           (date (encode-time 0 0 12 25 11 2024))
+           (org-capture-templates
+            `(("j" "Journal" entry
+               (function ,(lambda () (vulpea-journal-capture-target date)))
+               "* CAPTURED"
+               :immediate-finish t))))
+      ;; No note before capture.
+      (should-not (vulpea-journal-find-note date))
+      (org-capture nil "j")
+      ;; The day note exists and is a proper journal note in the DB.
+      (let ((found (vulpea-journal-find-note date)))
+        (should found)
+        (should (vulpea-note-id found))
+        (should (vulpea-journal-note-p found))))))
+
 (provide 'vulpea-journal-test)
 ;;; vulpea-journal-test.el ends here

--- a/vulpea-journal.el
+++ b/vulpea-journal.el
@@ -716,6 +716,48 @@ the specific heading note. Returns nil if not visiting a journal note."
         (message "No previous journal entry")))))
 
 
+;;; Capture Integration
+
+(declare-function org-capture-target-buffer "org-capture" (file))
+(declare-function org-find-entry-with-id "org" (ident))
+
+;;;###autoload
+(defun vulpea-journal-capture-target (&optional date)
+  "Set buffer and point to the journal note for DATE for `org-capture'.
+
+Use this as a `(function ...)' target in `org-capture-templates' to
+capture straight into the journal without opening the vulpea-ui sidebar.
+The note for DATE (today when DATE is nil) is created on demand, so the
+first capture of a day also registers the note in the vulpea database.
+
+Point placement follows the active template, so `entry' captures land
+where you would expect:
+
+- daily (file-level) templates: point goes to the top of the file and
+  `org-capture' appends the entry as a new top-level heading;
+- monthly (heading-level) templates: point goes onto the day's heading,
+  so the entry nests as a child of that day.
+
+The function only positions point; the capture type (`entry', `item',
+`plain', ...) and content come from your template."
+  (require 'org-capture)
+  (let* ((date (or date (current-time)))
+         (note (vulpea-journal-note date))
+         (file (vulpea-note-path note)))
+    (set-buffer (org-capture-target-buffer file))
+    (unless (derived-mode-p 'org-mode)
+      (org-mode))
+    (widen)
+    (if (> (or (vulpea-note-level note) 0) 0)
+        ;; Heading-level entry (monthly): land on the day's heading so
+        ;; `org-capture' treats it as the parent and nests the capture.
+        (goto-char (or (org-find-entry-with-id (vulpea-note-id note))
+                       (point-max)))
+      ;; File-level entry (daily): land at the top, a non-heading
+      ;; position, so `org-capture' appends a top-level heading at end.
+      (goto-char (point-min)))))
+
+
 ;;; Calendar Integration
 
 (defface vulpea-journal-calendar-entry-face


### PR DESCRIPTION
Adds `vulpea-journal-capture-target`, an `org-capture` target so you can jot straight into today's journal note without the vulpea-ui sidebar popping up.

Drop it into a capture template as a `(function ...)` target:

```elisp
(add-to-list 'org-capture-templates
             '("j" "Journal" entry
               (function vulpea-journal-capture-target)
               "* %U %?"))
```

It creates today's note on demand (the first capture of the day also registers it in the vulpea database) and positions point based on the active template: for daily templates the entry is appended as a top-level heading, for monthly templates it nests under today's day heading. The function only positions point, so the capture type (`entry`, `item`, `plain`, ...) and the content come from your template. Takes an optional `DATE` arg for a specific day.

Comes from #34, where the ask was to write something down quickly without the sidebar and widgets getting in the way. The thread landed on org-capture being the ideal fit (lets them drop a separate inbox.org), so this is that integration rather than a pile of no-sidebar sibling commands.

Includes a new Capture section in the README and a changelog entry.

Refs #34
