### PR TITLE
feat: add :entry-order to monthly templates

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -5,9 +5,11 @@
 ** Features
 
 - New =vulpea-journal-capture-target= function for capturing straight into the journal via =org-capture=, without opening the vulpea-ui sidebar. Use it as a =(function ...)= target in =org-capture-templates=. It creates today's note on demand (registering it in the database on the first capture of the day) and positions point so that =entry= captures append as a top-level heading for daily templates, or nest under the day's heading for monthly templates. Accepts an optional =DATE= argument to capture into a specific day. ([[https://github.com/d12frosted/vulpea-journal/issues/34][#34]])
+- Monthly templates can keep the newest day at the top of the file via the new =:entry-order= key of =vulpea-journal-template-monthly= (=oldest-first= by default, =newest-first= to reverse). Insertion is date-aware in both directions, so an entry created for a past date lands between its date neighbors instead of at the edge of the file. With =:entry-groups=, newly created group headings follow the same direction. ([[https://github.com/d12frosted/vulpea-journal/issues/37][#37]])
 
 ** Fixed
 
+- Fix a back-dated entry (created by visiting a past date) being appended at the bottom of the monthly file regardless of its date. It is now inserted between its date neighbors, keeping the file in date order. ([[https://github.com/d12frosted/vulpea-journal/issues/37][#37]])
 - Fix visiting a note from the Previous Years widget not setting the active date, which left the sidebar showing the old date. The widget now navigates via =vulpea-journal-ui--visit-date= like the rest of the sidebar. Thanks to [[https://github.com/drcxd][@drcxd]]. ([[https://github.com/d12frosted/vulpea-journal/pull/31][#31]])
 - Fix widget names in the README widget order table: registered names are =journal-created-today= and =journal-previous-years=, not =created-today= and =previous-years=. Also document that =vulpea-journal-ui-widget-orders= (short keys, read at registration time) and =vulpea-ui-widget-set= (full =journal-*= names, works on live registry) are two different ways to control widget order. ([[https://github.com/d12frosted/vulpea-journal/issues/29][#29]])
 

--- a/README.org
+++ b/README.org
@@ -182,6 +182,7 @@ Monthly template parameters:
 | =:entry-level=  | =1=                 | Heading level for daily entries (derived when =:entry-groups= is set) |
 | =:entry-title=  | =%d %A=             | strftime format for heading      |
 | =:entry-groups= | =nil=               | Optional grouping headings (see below) |
+| =:entry-order=  | =oldest-first=      | Direction of day entries in the file (see below) |
 | =:aliases=      | =nil=               | Per-entry aliases, computed or static (see below) |
 | =:tags=         | =("journal")=       | Tags (first one identifies journals) |
 
@@ -216,6 +217,28 @@ Each element of =:entry-groups= adds one heading level between the file and the 
 #+end_example
 
 Because =:body= is inserted verbatim at fixed heading levels, nest its subheadings one level below the entry (=***= for entries at level 2, as above).
+
+*** Entry order
+
+By default the monthly file reads chronologically: the oldest day sits at the top and new days are added at the bottom. Set =:entry-order= to =newest-first= to keep the most recent day at the top instead. This is useful on mobile, where reaching today's entry otherwise means scrolling through the whole month:
+
+#+begin_src emacs-lisp
+(setq vulpea-journal-default-template
+      (vulpea-journal-template-monthly
+       :entry-order 'newest-first))
+#+end_src
+
+#+begin_example
+#+title: 2026-07
+#+filetags: :journal:
+* 23 Thursday
+* 18 Saturday
+* 10 Friday
+#+end_example
+
+Insertion is date-aware in both directions: creating an entry for a past date (say, visiting July 15 with the file above) places it between its date neighbors instead of at the edge of the file. Only the day headings are ordered this way; whatever you add inside a day keeps its usual order (for captures, org-capture's =:prepend= flag controls that).
+
+With =:entry-groups=, newly created group headings follow the same direction. Group headings carry no date, so their placement is positional: a group created for a back-dated entry is prepended (or appended) rather than sorted.
 
 *** Entry aliases
 

--- a/test/vulpea-journal-test.el
+++ b/test/vulpea-journal-test.el
@@ -44,6 +44,21 @@
        (when (file-directory-p temp-dir)
          (delete-directory temp-dir t)))))
 
+(defun vulpea-journal-test--file-contents (file)
+  "Return current contents of FILE, saving any live buffer first."
+  (let ((buf (get-file-buffer file)))
+    (when (and buf (buffer-modified-p buf))
+      (with-current-buffer buf (save-buffer))))
+  (with-temp-buffer
+    (insert-file-contents file)
+    (buffer-string)))
+
+(defun vulpea-journal-test--heading-pos (content heading)
+  "Return position of HEADING regexp in CONTENT, failing if absent."
+  (let ((pos (string-match heading content)))
+    (should pos)
+    pos))
+
 ;;; Journal File Path Tests
 
 (ert-deftest vulpea-journal-file-path-relative ()
@@ -380,6 +395,19 @@ after a full scan rebuild."
     (should (equal (plist-get tpl :entry-groups) '("week %V")))
     (should (= (plist-get tpl :entry-level) 2))))
 
+(ert-deftest vulpea-journal-template-monthly-entry-order ()
+  "Test :entry-order is stored and validated by the monthly builder."
+  ;; Default: no :entry-order key, behavior is oldest-first.
+  (let ((tpl (vulpea-journal-template-monthly)))
+    (should-not (plist-member tpl :entry-order)))
+  ;; Explicit values are stored as-is.
+  (let ((tpl (vulpea-journal-template-monthly :entry-order 'newest-first)))
+    (should (eq (plist-get tpl :entry-order) 'newest-first)))
+  (let ((tpl (vulpea-journal-template-monthly :entry-order 'oldest-first)))
+    (should (eq (plist-get tpl :entry-order) 'oldest-first)))
+  ;; Invalid value fails at template construction time.
+  (should-error (vulpea-journal-template-monthly :entry-order 'append)))
+
 ;;; Template Helper Tests
 
 (ert-deftest vulpea-journal-heading-entry-p-daily ()
@@ -639,6 +667,142 @@ after a full scan rebuild."
         (should (string= (vulpea-note-id (vulpea-journal-find-note date3))
                          (vulpea-note-id note3)))))))
 
+;;; Entry Order Tests
+
+(ert-deftest vulpea-journal-monthly-oldest-first-appends ()
+  "Test default order appends new days at the bottom of the file."
+  (vulpea-test--with-temp-db
+    (let* ((vulpea-journal-default-template (vulpea-journal-template-monthly))
+           (date1 (encode-time 0 0 12 20 11 2024))
+           (date2 (encode-time 0 0 12 25 11 2024))
+           (date3 (encode-time 0 0 12 30 11 2024)))
+      ;; Created in chronological order, as days pass.
+      (vulpea-journal-note date1)
+      (vulpea-journal-note date2)
+      (vulpea-journal-note date3)
+      (let* ((content (vulpea-journal-test--file-contents
+                       (vulpea-journal--file-for-date date1)))
+             (p20 (vulpea-journal-test--heading-pos content "^\\* 20 Wednesday"))
+             (p25 (vulpea-journal-test--heading-pos content "^\\* 25 Monday"))
+             (p30 (vulpea-journal-test--heading-pos content "^\\* 30 Saturday")))
+        (should (< p20 p25))
+        (should (< p25 p30))))))
+
+(ert-deftest vulpea-journal-monthly-oldest-first-backdated ()
+  "Test default order places a back-dated day between its neighbors."
+  (vulpea-test--with-temp-db
+    (let* ((vulpea-journal-default-template (vulpea-journal-template-monthly))
+           (date-new (encode-time 0 0 12 25 11 2024))
+           (date-old (encode-time 0 0 12 10 11 2024))
+           (date-mid (encode-time 0 0 12 18 11 2024)))
+      ;; Today's entry exists first; older days are visited afterwards.
+      (vulpea-journal-note date-new)
+      (vulpea-journal-note date-old)
+      (vulpea-journal-note date-mid)
+      (let* ((content (vulpea-journal-test--file-contents
+                       (vulpea-journal--file-for-date date-new)))
+             (p10 (vulpea-journal-test--heading-pos content "^\\* 10 Sunday"))
+             (p18 (vulpea-journal-test--heading-pos content "^\\* 18 Monday"))
+             (p25 (vulpea-journal-test--heading-pos content "^\\* 25 Monday")))
+        ;; Chronological despite creation order 25, 10, 18.
+        (should (< p10 p18))
+        (should (< p18 p25)))
+      ;; All entries remain findable by date.
+      (should (vulpea-journal-find-note date-new))
+      (should (vulpea-journal-find-note date-old))
+      (should (vulpea-journal-find-note date-mid)))))
+
+(ert-deftest vulpea-journal-monthly-newest-first-order ()
+  "Test newest-first keeps the most recent day at the top of the file."
+  (vulpea-test--with-temp-db
+    (let* ((vulpea-journal-default-template
+            (vulpea-journal-template-monthly :entry-order 'newest-first))
+           (date1 (encode-time 0 0 12 20 11 2024))
+           (date2 (encode-time 0 0 12 25 11 2024))
+           (date3 (encode-time 0 0 12 30 11 2024)))
+      ;; Created in chronological order, as days pass.
+      (vulpea-journal-note date1)
+      (vulpea-journal-note date2)
+      (vulpea-journal-note date3)
+      (let* ((content (vulpea-journal-test--file-contents
+                       (vulpea-journal--file-for-date date1)))
+             (p20 (vulpea-journal-test--heading-pos content "^\\* 20 Wednesday"))
+             (p25 (vulpea-journal-test--heading-pos content "^\\* 25 Monday"))
+             (p30 (vulpea-journal-test--heading-pos content "^\\* 30 Saturday")))
+        ;; Newest day first.
+        (should (< p30 p25))
+        (should (< p25 p20)))
+      ;; All entries remain findable by date.
+      (should (vulpea-journal-find-note date1))
+      (should (vulpea-journal-find-note date2))
+      (should (vulpea-journal-find-note date3)))))
+
+(ert-deftest vulpea-journal-monthly-newest-first-backdated ()
+  "Test newest-first places a back-dated day between its neighbors."
+  (vulpea-test--with-temp-db
+    (let* ((vulpea-journal-default-template
+            (vulpea-journal-template-monthly :entry-order 'newest-first))
+           (date-new (encode-time 0 0 12 25 11 2024))
+           (date-old (encode-time 0 0 12 10 11 2024))
+           (date-mid (encode-time 0 0 12 18 11 2024)))
+      ;; Today's entry exists first; older days are visited afterwards.
+      (vulpea-journal-note date-new)
+      (vulpea-journal-note date-old)
+      (vulpea-journal-note date-mid)
+      (let* ((content (vulpea-journal-test--file-contents
+                       (vulpea-journal--file-for-date date-new)))
+             (p10 (vulpea-journal-test--heading-pos content "^\\* 10 Sunday"))
+             (p18 (vulpea-journal-test--heading-pos content "^\\* 18 Monday"))
+             (p25 (vulpea-journal-test--heading-pos content "^\\* 25 Monday")))
+        ;; Reverse chronological despite creation order 25, 10, 18.
+        (should (< p25 p18))
+        (should (< p18 p10))))))
+
+(ert-deftest vulpea-journal-monthly-newest-first-groups ()
+  "Test newest-first orders group headings and entries within groups."
+  (vulpea-test--with-temp-db
+    (let* ((vulpea-journal-default-template
+            (vulpea-journal-template-monthly
+             :entry-groups '("week %V")
+             :entry-order 'newest-first))
+           (d1 (encode-time 0 0 12 8 6 2026))    ; week 24, Monday
+           (d2 (encode-time 0 0 12 9 6 2026))    ; week 24, Tuesday
+           (d3 (encode-time 0 0 12 15 6 2026)))  ; week 25, Monday
+      (let ((n1 (vulpea-journal-note d1))
+            (n2 (vulpea-journal-note d2))
+            (n3 (vulpea-journal-note d3)))
+        ;; Nesting is unchanged: entries live under their week heading.
+        (should (equal (vulpea-note-outline-path n1) '("week 24")))
+        (should (equal (vulpea-note-outline-path n2) '("week 24")))
+        (should (equal (vulpea-note-outline-path n3) '("week 25")))
+        (let* ((content (vulpea-journal-test--file-contents
+                         (vulpea-note-path n1)))
+               (pw24 (vulpea-journal-test--heading-pos content "^\\* week 24"))
+               (pw25 (vulpea-journal-test--heading-pos content "^\\* week 25"))
+               (p08 (vulpea-journal-test--heading-pos content "^\\*\\* 08 Monday"))
+               (p09 (vulpea-journal-test--heading-pos content "^\\*\\* 09 Tuesday")))
+          ;; The newer week heading sits above the older one.
+          (should (< pw25 pw24))
+          ;; Within a week, the newer day sits above the older one.
+          (should (< p09 p08)))
+        ;; All entries remain findable by date.
+        (should (vulpea-journal-find-note d1))
+        (should (vulpea-journal-find-note d2))
+        (should (vulpea-journal-find-note d3))))))
+
+(ert-deftest vulpea-journal-monthly-entry-order-invalid ()
+  "Test an invalid :entry-order in a raw template plist errors at creation."
+  (vulpea-test--with-temp-db
+    (let* ((vulpea-journal-default-template
+            '(:file-name "journal/%Y-%m.org"
+              :title "%Y-%m"
+              :tags ("journal")
+              :entry-level 1
+              :entry-title "%d %A"
+              :entry-order prepend))
+           (date (encode-time 0 0 12 25 11 2024)))
+      (should-error (vulpea-journal-note date)))))
+
 (ert-deftest vulpea-journal-monthly-all-dates ()
   "Test all-dates includes entries from monthly templates."
   (vulpea-test--with-temp-db
@@ -719,15 +883,6 @@ after a full scan rebuild."
 ;;; Capture Target Tests
 
 (require 'org-capture)
-
-(defun vulpea-journal-test--file-contents (file)
-  "Return current contents of FILE, saving any live buffer first."
-  (let ((buf (get-file-buffer file)))
-    (when (and buf (buffer-modified-p buf))
-      (with-current-buffer buf (save-buffer))))
-  (with-temp-buffer
-    (insert-file-contents file)
-    (buffer-string)))
 
 (ert-deftest vulpea-journal-capture-target-daily ()
   "Daily capture lands as a top-level heading in the day's file."

--- a/vulpea-journal.el
+++ b/vulpea-journal.el
@@ -148,6 +148,16 @@ wrapped in a one-element list.  Shared by :entry-groups and :aliases."
    ((listp specs) specs)
    (t (error "Invalid template spec list: %S" specs))))
 
+(defun vulpea-journal--normalize-entry-order (order)
+  "Normalize the :entry-order template value ORDER.
+Returns `oldest-first' or `newest-first'; nil defaults to
+`oldest-first'.  Signals an error on any other value."
+  (pcase order
+    ('nil 'oldest-first)
+    ((or 'oldest-first 'newest-first) order)
+    (_ (error "Invalid :entry-order: %S (expected oldest-first or newest-first)"
+              order))))
+
 (cl-defun vulpea-journal-template-daily (&key
                                          (file-name "journal/%Y-%m-%d.org")
                                          (title "%Y-%m-%d %A")
@@ -184,6 +194,7 @@ All parameters are optional with sensible defaults:
                                            (entry-level 1)
                                            (entry-title "%d %A")
                                            entry-groups
+                                           entry-order
                                            aliases head body properties meta context)
   "Create a monthly journal template (one file per month).
 
@@ -207,6 +218,15 @@ All parameters are optional with sensible defaults:
   1 + number of groups so lookup and creation agree.  For example,
   :entry-groups \\='(\"week %V\") nests each day under a \"week NN\"
   heading and entries live at level 2.
+- ENTRY-ORDER: direction in which day entries are kept inside the
+  file.  `oldest-first' (default) keeps the oldest day at the top and
+  new days are added at the bottom; `newest-first' keeps the newest
+  day at the top, so the latest entry is visible without scrolling.
+  Insertion is date-aware in both directions: an entry created for a
+  past date is placed between its date neighbors rather than at the
+  edge of the file.  With ENTRY-GROUPS, newly created group headings
+  follow the same direction; group headings carry no date, so their
+  placement is positional (prepend or append at creation time).
 - ALIASES: optional note aliases, computed per entry.  Each element is
   a strftime string expanded for the entry's date (e.g. \"%Y-%m-%d\")
   or a function of one argument (DATE) returning the alias; a single
@@ -217,12 +237,16 @@ All parameters are optional with sensible defaults:
 - HEAD: applied to the monthly file (the container), not the entries.
 - META: file-level only; monthly heading entries do not carry meta,
   as `vulpea-create' supports meta on file-level notes only."
+  ;; Reject invalid values at construction time rather than on first
+  ;; entry creation.
+  (vulpea-journal--normalize-entry-order entry-order)
   (let* ((groups (vulpea-journal--normalize-specs entry-groups))
          (entry-level (if groups (1+ (length groups)) entry-level)))
     (append
      (list :file-name file-name :title title :tags tags
            :entry-level entry-level :entry-title entry-title)
      (when groups (list :entry-groups groups))
+     (when entry-order (list :entry-order entry-order))
      (when aliases (list :aliases (vulpea-journal--normalize-specs aliases)))
      (when head (list :head head))
      (when body (list :body body))
@@ -498,13 +522,67 @@ first.  Returns the matching `vulpea-note' or nil."
         (equal (vulpea-note-outline-path it) outline-path))
    (vulpea-journal--query-file-notes file level)))
 
-(defun vulpea-journal--ensure-group-path (container date groups)
+(defun vulpea-journal--sibling-entries (parent)
+  "Return notes that are direct children of PARENT.
+PARENT is a `vulpea-note': the monthly container or the deepest
+grouping heading.  Children are queried from the database, which
+`vulpea-create' updates synchronously, so entries created moments
+ago are visible."
+  (let ((path (if (= (vulpea-note-level parent) 0)
+                  nil
+                (append (vulpea-note-outline-path parent)
+                        (list (vulpea-note-title parent))))))
+    (--filter (equal (vulpea-note-outline-path it) path)
+              (vulpea-journal--query-file-notes
+               (vulpea-note-path parent)
+               (1+ (vulpea-note-level parent))))))
+
+(defun vulpea-journal--entry-after (parent date order)
+  "Return `:after' placement for a new entry on DATE under PARENT.
+ORDER is a normalized :entry-order value (`oldest-first' or
+`newest-first').  The result is suitable for `vulpea-create':
+`last' to append, nil to insert as first child, or a sibling ID to
+insert after that sibling's subtree.
+
+Placement keeps sibling day entries sorted by date in the direction
+given by ORDER, so an entry created for a past date lands between
+its date neighbors instead of at the edge of the file.  Siblings
+without a CREATED date (e.g. manually added headings) are ignored."
+  (let* ((day (format-time-string "%Y-%m-%d" date))
+         (dated (-keep
+                 (lambda (note)
+                   (when-let* ((d (vulpea-journal--date-from-created note)))
+                     (cons (format-time-string "%Y-%m-%d" d) note)))
+                 (vulpea-journal--sibling-entries parent)))
+         (newer (--filter (string> (car it) day) dated))
+         (older (--filter (string< (car it) day) dated)))
+    (if (eq order 'newest-first)
+        ;; Descending file: insert after the closest newer sibling,
+        ;; or as first child when DATE is the newest so far.
+        (when newer
+          (vulpea-note-id
+           (cdr (car (-sort (lambda (a b) (string< (car a) (car b)))
+                            newer)))))
+      ;; Ascending file: append when DATE is the newest so far (the
+      ;; common case), otherwise insert after the closest older
+      ;; sibling, falling back to first child when DATE is the oldest.
+      (cond
+       ((null newer) 'last)
+       ((null older) nil)
+       (t (vulpea-note-id
+           (cdr (car (-sort (lambda (a b) (string> (car a) (car b)))
+                            older)))))))))
+
+(defun vulpea-journal--ensure-group-path (container date groups order)
   "Ensure the chain of GROUPS headings under CONTAINER for DATE.
 CONTAINER is the file-level container `vulpea-note'.  GROUPS is a
 list of group specs (see `vulpea-journal--resolve-spec').
 Missing group headings are created on demand and existing ones are
-reused.  Returns the deepest container note that should parent the
-entry, which is CONTAINER itself when GROUPS is empty."
+reused.  ORDER is a normalized :entry-order value; group headings
+carry no date, so a new group is simply prepended for
+`newest-first' and appended otherwise.  Returns the deepest
+container note that should parent the entry, which is CONTAINER
+itself when GROUPS is empty."
   (let ((parent container)
         (file (vulpea-note-path container))
         (ancestry nil))
@@ -519,21 +597,28 @@ entry, which is CONTAINER itself when GROUPS is empty."
         (setq parent (or existing
                          (vulpea-create title nil
                                         :parent parent
-                                        :after 'last)))
+                                        :after (if (eq order 'newest-first)
+                                                   nil
+                                                 'last))))
         (push title ancestry)))))
 
 (defun vulpea-journal--create-heading-note (date tpl)
   "Create a heading-level journal note for DATE using template TPL.
 When TPL has a non-nil :entry-groups, the entry is nested under the
-chain of date-derived grouping headings (created on demand)."
+chain of date-derived grouping headings (created on demand).
+Placement among siblings honors the template :entry-order (see
+`vulpea-journal-template-monthly')."
   (let* ((file (vulpea-journal--file-for-date date))
          (entry-title (vulpea-journal--entry-title-for-date date))
          (date-str (format-time-string "[%Y-%m-%d]" date))
+         ;; Validate the order before touching any file.
+         (order (vulpea-journal--normalize-entry-order
+                 (plist-get tpl :entry-order)))
          ;; Find or create the container (file-level note), then walk
          ;; the optional chain of grouping headings for this date.
          (container (vulpea-journal--ensure-container file date tpl))
          (parent (vulpea-journal--ensure-group-path
-                  container date (plist-get tpl :entry-groups))))
+                  container date (plist-get tpl :entry-groups) order)))
     ;; Create heading entry under the deepest container.
     ;; Note: no :tags here - headings inherit filetags from container
     (vulpea-create
@@ -544,7 +629,7 @@ chain of date-derived grouping headings (created on demand)."
      :properties (vulpea-journal--entry-properties
                   tpl date `(("CREATED" . ,date-str)))
      :context (plist-get tpl :context)
-     :after 'last)))
+     :after (vulpea-journal--entry-after parent date order))))
 
 (defun vulpea-journal--ensure-container (file date tpl)
   "Ensure monthly container file exists at FILE for DATE.


### PR DESCRIPTION
Adds an `:entry-order` key to `vulpea-journal-template-monthly`. By default nothing changes: the monthly file stays chronological, new days are appended at the bottom. With `newest-first` the latest day is kept at the top, so it is visible right away without scrolling through the whole month. That is the mobile use case from #37.

```elisp
(setq vulpea-journal-default-template
      (vulpea-journal-template-monthly :entry-order 'newest-first))
```

Insertion is date-aware in both directions: creating an entry for a past date places it between its date neighbors instead of at the edge of the file. This also fixes a quirk in the default order, where a back-dated entry was appended at the bottom regardless of its date.

With `:entry-groups`, newly created group headings follow the same direction. Group headings carry no date, so their placement is positional (prepend or append at creation time), not sorted.

Only the day headings are ordered this way. Content inside a day keeps its usual order; for captures, org-capture's `:prepend` flag decides that.

Closes #37
