### PR TITLE
fix: close calendar window in `vulpea-journal-calendar-open`

### DIFF
--- a/vulpea-journal.el
+++ b/vulpea-journal.el
@@ -896,6 +896,7 @@ Falls back to `org-eval-in-calendar' on Org < 9.8."
   (interactive)
   (let ((date (calendar-cursor-to-date t)))
     (when date
+      (calendar-exit)
       (vulpea-journal (encode-time 0 0 0
                                    (nth 1 date)   ; day
                                    (nth 0 date)   ; month


### PR DESCRIPTION
Call `calendar-exit` to close the calendar window. This avoids the journal note being displayed in the same window where the calendar was. Also, if the user has configured `display-buffer-alist` to open journal files in a dedicated tab, this avoids leaving the calendar open in the previous tab.